### PR TITLE
Mailgun EU Region Domains

### DIFF
--- a/essentials/configuration.md
+++ b/essentials/configuration.md
@@ -12,10 +12,14 @@ moduleSettings = {
         // Default protocol to use, it must be defined in the mailers configuration
         defaultProtocol : "default",
         // Here you can register one or many mailers by name
-        mailers         : { 
+        mailers         : {
             "default" : { class : "CFMail" },
             "files" : { class:"File", properties : { filePath : "/logs" } },
-            "postmark" : { class:"PostMark", properties : { apiKey : "234" } } 
+            "postmark" : { class:"PostMark", properties : { apiKey : "234" } },
+            "mailgun" : { class:"Mailgun", properties : {
+				apiKey : "234",
+				domain: 'mailgun.example.com'
+			} }
         },
         // The defaults for all mail config payloads and protocols
         defaults        : {
@@ -109,7 +113,7 @@ mailers : {
 		class = "Postmark",
 		// Required properties
 		properties = {
-			APIKey = "123"
+			apiKey = "123"
 		}
 	},
 
@@ -118,8 +122,12 @@ mailers : {
 		class = "Mailgun",
 		// Required properties
 		properties = {
-			ApiKey  = '123',
-			domain  = 'mg.somedomain.com'
+			apiKey  = "123",
+			domain  = "mailgun.example.com",
+			// Optional property, defaults to https://api.mailgun.net/v3/
+			// https://documentation.mailgun.com/en/latest/api-intro.html#base-url-1
+			// https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions-1
+			baseURL = "https://api.eu.mailgun.net/v3/" // for the EU region
 		}
 	};
 }

--- a/essentials/sending-mail.md
+++ b/essentials/sending-mail.md
@@ -12,21 +12,21 @@ Please note that the mixin helper can **ONLY** be used in handlers, interceptors
 
 ```javascript
 // Mixin Helper Approach
-newMail( 
+newMail(
 	to         : "email@email.com",
 	from       : "no_reply@ortussolutions.com",
 	subject    : "Mail Services Rock",
 	type       : "html", // Can be plain, html, or text
-	bodyTokens : { 
-		user    : "Luis", 
-		product : "ColdBox", 
+	bodyTokens : {
+		user    : "Luis",
+		product : "ColdBox",
 		link    : event.buildLink( 'home' )
 	}
 )
 .setBody("
     <p>Dear @user@,</p>
     <p>Thank you for downloading @product@, have a great day!</p>
-    <p><a href='@link@'>@link@</a></p> 
+    <p><a href='@link@'>@link@</a></p>
 ")
 .send()
 .onSuccess( function( result, mail ){
@@ -67,21 +67,21 @@ component{
 		...
 
 		variables.mailService
-		.newMail( 
+		.newMail(
 			to         : "email@email.com",
 			from       : "no_reply@ortussolutions.com",
 			subject    : "Mail Services Rock",
 			type       : "html",
-			bodyTokens : { 
-				user    : "Luis", 
-				product : "ColdBox", 
+			bodyTokens : {
+				user    : "Luis",
+				product : "ColdBox",
 				link    : event.buildLink( 'home' )
 			}
 		)
 		.setBody("
 			<p>Dear @user@,</p>
 			<p>Thank you for downloading @product@, have a great day!</p>
-			<p><a href='@link@'>@link@</a></p> 
+			<p><a href='@link@'>@link@</a></p>
 		")
 		.send()
 		.onSuccess( function( result, mail ){
@@ -112,14 +112,14 @@ The `newMail()` or `configure()` method is used to initiate and configure a mail
 
 ```javascript
 variables.mailService
-.newMail( 
+.newMail(
 	to         : "email@email.com",
 	from       : "no_reply@ortussolutions.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
-	bodyTokens : { 
-		user    : "Luis", 
-		product : "ColdBox", 
+	bodyTokens : {
+		user    : "Luis",
+		product : "ColdBox",
 		link    : event.buildLink( 'home' )
 	}
 )
@@ -130,9 +130,9 @@ newMail()
 	from       : "no_reply@ortussolutions.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
-	bodyTokens : { 
-		user    : "Luis", 
-		product : "ColdBox", 
+	bodyTokens : {
+		user    : "Luis",
+		product : "ColdBox",
 		link    : event.buildLink( 'home' )
 	}
 )
@@ -188,39 +188,39 @@ Before sending the mail, the service will replace all the tokens with the specif
 
 ```javascript
 // Via constructor
-newMail( 
+newMail(
 	to         : "email@email.com",
 	from       : "no_reply@ortussolutions.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
-	bodyTokens : { 
-		user    : "Luis", 
-		product : "ColdBox", 
+	bodyTokens : {
+		user    : "Luis",
+		product : "ColdBox",
 		link    : event.buildLink( 'home' )
 	}
 )
 .setBody("
 	<p>Dear @user@,</p>
 	<p>Thank you for downloading @product@, have a great day!</p>
-	<p><a href='@link@'>@link@</a></p> 
+	<p><a href='@link@'>@link@</a></p>
 ")
 .send()
 
 // Body Tokens Method
-newMail( 
+newMail(
 	to         : "email@email.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
 )
-.setBodyTokens( { 
-	user    : "Luis", 
-	product : "ColdBox", 
+.setBodyTokens( {
+	user    : "Luis",
+	product : "ColdBox",
 	link    : event.buildLink( 'home' )
 })
 .setBody("
 	<p>Dear @user@,</p>
 	<p>Thank you for downloading @product@, have a great day!</p>
-	<p><a href='@link@'>@link@</a></p> 
+	<p><a href='@link@'>@link@</a></p>
 ")
 .send()
 ```
@@ -254,20 +254,20 @@ Mail function setView(
 Please note that you can bind your views and layotus with the `args` structure as well. You can also use the `bodyTokens` in your views. Then you can use it in your mail sending goodness:
 
 ```javascript
-newMail( 
+newMail(
 	to         : "email@email.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
 )
-.setBodyTokens( { 
-	user    : "Luis", 
-	product : "ColdBox", 
+.setBodyTokens( {
+	user    : "Luis",
+	product : "ColdBox",
 	link    : event.buildLink( 'home' )
 })
 .setView( view : "emails/newUser" )
 .send()
 
-newMail( 
+newMail(
 	to         : "email@email.com",
 	subject    : "Mail Services Rock",
 	type       : "html",
@@ -323,7 +323,7 @@ You can easily add mail parameters (`cfmailparam`) to a payload so you can attac
 ```javascript
 /**
  * Attach a file or adss a header to the email payload
- * 
+ *
  * @contentID The Identifier for the attached file.
  * @disposition How the attached file is to be handled: attachment, inline
  * @file Attaches file to a message. Mutually exclusive with name argument.
@@ -331,7 +331,7 @@ You can easily add mail parameters (`cfmailparam`) to a payload so you can attac
  * @name The name of the email header to attach. See https://cfdocs.org/cfmailparam. Mututally exclusive with file
  * @value The value of the header
  * @remove Tells ColdFusion to remove any attachments after sucdcesful mail delivery
- * @content Lets you send the contents of a ColdFusion variable as an attachment 
+ * @content Lets you send the contents of a ColdFusion variable as an attachment
  */
 Mail function addMailParam(
 	contentID,
@@ -372,7 +372,7 @@ You can also add mail parts via the `cfmailpart` feature of `cfmail` (https://cf
 ```javascript
 /**
  * Add a new mail part to this mail payload
- * 
+ *
  * @charset The charset of the part, defaults to utf-8
  * @type The valid mime type: text/plain or text/html
  * @wraptext Specifies the maximum line length, in characters of the mail text.
@@ -425,6 +425,6 @@ The `Mail` object has some additional methods to allow you to pass additional in
 mail.setAdditionalInfo( struct );
 mail.getAdditionalInfo();
 
-mail.seavatAdditionalInfoItem( key, value );
+mail.setAdditionalInfoItem( key, value );
 mail.getAdditionalInfoItem( key );
 ```


### PR DESCRIPTION
As currently coded the Mailgun protocol assumes a US region domain. If the domain is associated with the EU region it just returns "Forbidden", not even a JSON formatted string! As a result all call fails. Documentation updated to reflect support for EU region domains.